### PR TITLE
feat: about page markdown, draft posts

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -4,7 +4,6 @@ import Footer from "@components/Footer.astro";
 import "@fontsource/inter/variable.css";
 import "@fontsource/fira-code/variable.css";
 
-
 let { pubDate } = Astro.props.content;
 const { frontmatter } = Astro.props;
 const canonicalURL = new URL(Astro.url).href;
@@ -26,7 +25,8 @@ const defaultMeta = {
   imageAlt: "Mountain Logo with NoFuss",
 };
 
-const { heroImage = defaultMeta.image, imageAlt = defaultMeta.imageAlt } = Astro.props as Props;
+const { heroImage = defaultMeta.image, imageAlt = defaultMeta.imageAlt } =
+  Astro.props as Props;
 
 const classBody =
   "scrollbar-thin scrollbar-thumb-zinc-400 scrollbar-track-zinc-300 dark:scrollbar-thumb-zinc-600 dark:scrollbar-track-zinc-800 dark:bg-zinc-900 dark:text-white font-inter selection:bg-blue-500/70 text-xl";
@@ -63,14 +63,19 @@ const classBody =
     <meta name="author" content="Lance Ross" />
     <script is:inline>
       const primaryColorScheme = "none";
-      const darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const darkModeMediaQuery = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
       const currentTheme = localStorage.getItem("theme");
 
       let theme;
       if (currentTheme) {
         theme = currentTheme === "dark" ? "dark" : "";
       } else {
-        if (primaryColorScheme === "dark" || (primaryColorScheme === "none" && darkModeMediaQuery)) {
+        if (
+          primaryColorScheme === "dark" ||
+          (primaryColorScheme === "none" && darkModeMediaQuery)
+        ) {
           theme = "dark";
         } else if (primaryColorScheme === "light") {
           theme = "";
@@ -94,7 +99,12 @@ const classBody =
         </article>
       </section>
       <div class="flex flex-row justify-between">
-        <a href="/blog" class="dark:text-blue-400 text-blue-600 hover:underline mt-5">Go back to posts</a>
+        <a
+          href="/blog"
+          class="dark:text-blue-400 text-blue-600 hover:underline mt-5"
+        >
+          Go back to posts
+        </a>
       </div>
     </main>
     <Footer />
@@ -103,9 +113,9 @@ const classBody =
 
 <style is:global>
   .blogpost img {
-    border-radius: 14px!important;
+    border-radius: 14px !important;
     margin: 20px auto;
-    max-width: calc(100% - 40px)
+    max-width: calc(100% - 40px);
   }
 
   .blogpost img[align="right"] {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,12 +12,18 @@ export interface Props {
 
 const defaultMeta = {
   title: "Bpall",
-  description: "No fuss Astro Template for Landing, Blog and Docs page. No complicated design and setup, just start editing.",
+  description:
+    "No fuss Astro Template for Landing, Blog and Docs page. No complicated design and setup, just start editing.",
   image: "/banner.png",
   imageAlt: "Mountain Logo with NoFuss",
 };
 
-const { title = defaultMeta.title, description = defaultMeta.description, heroImage = defaultMeta.image, imageAlt = defaultMeta.imageAlt } = Astro.props as Props;
+const {
+  title = defaultMeta.title,
+  description = defaultMeta.description,
+  heroImage = defaultMeta.image,
+  imageAlt = defaultMeta.imageAlt,
+} = Astro.props as Props;
 const canonicalURL = new URL(Astro.url).href;
 
 const classBody =
@@ -55,14 +61,19 @@ const classBody =
     <meta name="author" content="Lance Ross" />
     <script is:inline>
       const primaryColorScheme = "none";
-      const darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const darkModeMediaQuery = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
       const currentTheme = localStorage.getItem("theme");
 
       let theme;
       if (currentTheme) {
         theme = currentTheme === "dark" ? "dark" : "";
       } else {
-        if (primaryColorScheme === "dark" || (primaryColorScheme === "none" && darkModeMediaQuery)) {
+        if (
+          primaryColorScheme === "dark" ||
+          (primaryColorScheme === "none" && darkModeMediaQuery)
+        ) {
           theme = "dark";
         } else if (primaryColorScheme === "light") {
           theme = "";

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,7 +7,9 @@ import { Icon } from "astro-icon";
   <section class="grid place-items-center text-center overflow-hidden mt-9">
     <Icon name="mdi:stool" class="w-36 h-36" />
     <h1 class="my-8 text-5xl font-semibold">404 Error</h1>
-    <h2 class="text-2xl dark:text-zinc-300 mb-5">Sorry, it doesn't exist.</h2>
+    <h2 class="text-2xl dark:text-zinc-300 mb-5">
+      Sorry, this page doesn't exist.
+    </h2>
     <a
       href="/"
       class="dark:bg-zinc-800 bg-zinc-200 rounded-xl p-3 text-black dark:text-white m-2 ring-2 ring-opacity-0 ring-blue-500 hover:ring-opacity-100"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,17 +1,17 @@
 ---
 import Layout from "@layouts/Layout.astro";
 import { Icon } from "astro-icon";
+import * as about from "./about/about.mdx";
 ---
 
-<Layout title="Bpall" description="About Bpall">
-  <section class="grid place-items-center text-center overflow-hidden mt-9">
-    <Icon name="mdi:stool" class="w-36 h-36" />
-    <h1 class="my-8 text-5xl font-semibold"></h1>
-    <h2 class="text-2xl dark:text-zinc-300 mb-5">About Bpall</h2>
-    <a
-      href="/"
-      class="dark:bg-zinc-800 bg-zinc-200 rounded-xl p-3 text-black dark:text-white m-2 ring-2 ring-opacity-0 ring-blue-500 hover:ring-opacity-100"
-      >Go back to homepage</a
-    >
-  </section>
+<Layout title="About - Bpall" description="Bpall's about page">
+  <article
+    class="mx-auto blogpost text-justify mt-10 prose sm:prose-lg dark:text-slate-200 prose-a:dark:text-blue-400 prose-a:no-underline prose-pre:scrollbar-thin prose-pre:scrollbar-thumb-zinc-400 prose-pre:scrollbar-track-zinc-300 prose-pre:dark:scrollbar-thumb-zinc-500 prose-pre:dark:scrollbar-track-zinc-700 hover:prose-a:underline prose-a:text-blue-700 dark:prose-invert prose-a:underline-offset-2"
+  >
+    <about.Content />
+  </article>
+
+  <footer class="grid place-items-center text-center overflow-hidden mt-20">
+    <Icon name="mdi:stool" class="w-12 h-12" />
+  </footer>
 </Layout>

--- a/src/pages/about/about.mdx
+++ b/src/pages/about/about.mdx
@@ -1,0 +1,3 @@
+# About me (bpall)
+
+Ullamco et laborum proident enim proident. Nostrud ex amet ut consequat. Aute proident nulla velit labore excepteur irure. Nulla adipisicing ex proident dolor enim nisi cupidatat. Enim sit labore laborum nisi non ex sint nisi officia non enim ea.

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,28 +1,40 @@
 ---
 import Layout from "@layouts/Layout.astro";
 import BlogCard from "@components/BlogCard.astro";
+
 interface Frontmatter {
   title: string;
   pubDate: string;
   description: string;
+  draft?: boolean;
 }
-const metadata = {
-  title: "Blog - Bpall",
-  description: "Bpall's blog.",
-};
 
 let blogs = await Astro.glob<Frontmatter>("./blog/*.mdx");
-blogs = blogs.sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf());
+blogs = blogs.sort(
+  (a, b) =>
+    new Date(b.frontmatter.pubDate).valueOf() -
+    new Date(a.frontmatter.pubDate).valueOf()
+);
+
+blogs = blogs.filter((blog) => !blog.frontmatter.draft);
 ---
 
-<Layout {...metadata}>
+<Layout title="Bpall - Blog" description="Bpall's blog">
   <section>
-    <h1 class="sm:text-4xl text-3xl font-bold mb-6 dark:text-white">Blog</h1>
-    <p class="dark:text-zinc-300 mb-6">This is how the blog page looks like. Just add an MDX file to the blog folder and it will show up here.</p>
-  </section>
-  <section>
+    <h1 class="sm:text-4xl text-3xl font-bold mb-6 dark:text-white text-center">
+      Blog
+    </h1>
     <ul>
-      {blogs.map((post) => <BlogCard title={post.frontmatter.title} description={post.frontmatter.description} pubDate={post.frontmatter.pubDate} url={post.url} />)}
+      {
+        blogs.map((post) => (
+          <BlogCard
+            title={post.frontmatter.title}
+            description={post.frontmatter.description}
+            pubDate={post.frontmatter.pubDate}
+            url={post.url}
+          />
+        ))
+      }
     </ul>
   </section>
 </Layout>

--- a/src/pages/blog/demo.mdx
+++ b/src/pages/blog/demo.mdx
@@ -2,8 +2,10 @@
 title: Markdown Styling
 description: "Markdown Styling for Blog Posts"
 pubDate: November 30, 2022
+draft: true
 ---
-import Image from "@components/Image.astro"
+
+import Image from "@components/Image.astro";
 
 This is a test blog post to see how markdown styling works. I'm going to try to make this as long as possible to see how the styling works.
 
@@ -16,7 +18,6 @@ This is styled using `@tailwindcss/typography` plugin. Markdown sample is from [
 ## Paragraphs
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit 🤣, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id donec ultrices tincidunt arcu non sodales neque sodales. Adipiscing diam donec adipiscing tristique risus nec feugiat in.
-
 
 # Heading 1
 
@@ -54,7 +55,7 @@ This is really **_very_** important text.
 
 ### Unordered
 
-- Create a list by starting a line with "*-*" sign
+- Create a list by starting a line with "_-_" sign
 - Sub-lists are made by indenting 2 spaces:
   - Marker character change forces new list start:
     - Ac tristique libero volutpat at
@@ -84,23 +85,24 @@ This is an array `[1, 2, 3]` of numbers 1 through 3.
 ```html
 <h1>Code Block</h1>
 ```
+
 With code title:
 
 ```jsx title="src/components/Counter.jsx" {1}
-import { createSignal } from 'solid-js'
+import { createSignal } from "solid-js";
 
 export default function Counter() {
-  const [count, setCount] = createSignal(0)
+  const [count, setCount] = createSignal(0);
 
-  const add = () => setCount((i) => i + 1)
+  const add = () => setCount((i) => i + 1);
 
   return (
-    <div class='flex gap-x-4'>
-      <button type='button' onClick={add}>
+    <div class="flex gap-x-4">
+      <button type="button" onClick={add}>
         the count is {count()}
       </button>
     </div>
-  )
+  );
 }
 ```
 
@@ -116,13 +118,13 @@ export default function Counter() {
 
 ### Adding Titles
 
-[YouTube](https://youtube.com 'Go to YouTube')
+[YouTube](https://youtube.com "Go to YouTube")
 
-[My Website](https://lanceross.xyz 'Lance Ross')
+[My Website](https://lanceross.xyz "Lance Ross")
 
 ## Image
 
-> Image compress and resize by [`@astrojs/image`](https://docs.astro.build/en/guides/integrations-guide/image/ "@astrojs/image's guide"). 
+> Image compress and resize by [`@astrojs/image`](https://docs.astro.build/en/guides/integrations-guide/image/ "@astrojs/image's guide").
 
 Currently, my custom component for images only supports 16:9 aspect ratio or else it will squish the image.
 
@@ -133,9 +135,15 @@ Currently, my custom component for images only supports 16:9 aspect ratio or els
 
 ```
 
-<Image src="/images/jules-beagle-unsplash.jpg" alt="Beagle Dog by Jules D. on Unsplash" />
+<Image
+  src="/images/jules-beagle-unsplash.jpg"
+  alt="Beagle Dog by Jules D. on Unsplash"
+/>
 
-<Image src="/images/portrait-beagle-unsplash.jpg" alt="Beagle Dog by Jules D. on Unsplash" />
+<Image
+  src="/images/portrait-beagle-unsplash.jpg"
+  alt="Beagle Dog by Jules D. on Unsplash"
+/>
 
 ### Strikethrough
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,22 +1,39 @@
 ---
 import Layout from "@layouts/Layout.astro";
 import ProjectCard from "@components/ProjectCard.astro";
+import { Icon } from "astro-icon";
 
 type ProjectCard = {
   title: string;
   pubDate: string;
   description: string;
   imageSrc: string;
-}
+  draft?: boolean;
+};
 
 let projects = await Astro.glob<ProjectCard>("./projects/*.mdx");
-projects = projects.sort((a, b) => new Date(b.frontmatter.pubDate).valueOf() - new Date(a.frontmatter.pubDate).valueOf());
+projects = projects.sort(
+  (a, b) =>
+    new Date(b.frontmatter.pubDate).valueOf() -
+    new Date(a.frontmatter.pubDate).valueOf()
+);
+projects = projects.filter((project) => !project.frontmatter.draft);
 ---
 
 <Layout>
-  <section class="grid py-10 place-items-center text-center">
-    <h1 class="sm:text-4xl text-3xl font-bold mb-6 dark:text-white">Bpall</h1>
-    <p>Bpall's projects and blog</p>
+  <section class="flex flex-col gap-10 py-10">
+    <header
+      class="flex justify-center items-center text-5xl font-bold gap-5 pb-10"
+    >
+      <Icon name="mdi:stool" class="w-24 h-24" />
+      Bpall
+    </header>
+    <div>
+      {
+        projects.map((project) => (
+          <ProjectCard {...project.frontmatter} url={project.url} />
+        ))
+      }
+    </div>
   </section>
-  {projects.map((project) => <ProjectCard {...project.frontmatter} url={project.url} />)}
 </Layout>

--- a/src/pages/projects/test.mdx
+++ b/src/pages/projects/test.mdx
@@ -3,14 +3,19 @@ title: Project test
 description: Found some issues or want to contribute? Feel free to open an issue or pull request on GitHub.
 imageSrc: /images/portrait-beagle-unsplash.jpg
 pubDate: November 30, 2022
+draft: true
 ---
-import Image from "@components/Image.astro"
+
+import Image from "@components/Image.astro";
 
 ## This is my project
 
-it is cool 
+it is cool
 
-<Image src="/images/jules-beagle-unsplash.jpg" alt="Beagle Dog by Jules D. on Unsplash" />
+<Image
+  src="/images/jules-beagle-unsplash.jpg"
+  alt="Beagle Dog by Jules D. on Unsplash"
+/>
 
 ## this is a heading
 


### PR DESCRIPTION
- Added about page markdown file: `src/pages/about/about.mdx`
- Blogposts and project posts now have `draft` boolean in the metadata. I set the demo posts as drafts so they aren't included in the build